### PR TITLE
Any counterparty votingblock

### DIFF
--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -77,9 +77,9 @@ class VotingCommunity : Community() {
     /**
      * Return the tally on a vote proposal in a pair(yes, no).
      */
-    fun countVotes(voteName: String, proposerKey: ByteArray): Pair<Int, Int> {
+    fun countVotes(voters: List<String>, voteName: String, proposerKey: ByteArray): Pair<Int, Int> {
 
-        var voters: MutableList<String> = ArrayList()
+        var votes: MutableList<String> = ArrayList()
 
         var yesCount = 0
         var noCount = 0
@@ -87,9 +87,15 @@ class VotingCommunity : Community() {
         // Crawl the chain of the proposer.
         for (it in trustchain.getChainByUser(proposerKey)) {
 
-            if (voters.contains(it.publicKey.contentToString())){
+            if (votes.contains(it.publicKey.contentToString())){
                 continue
             }
+
+            if (!voters.contains(it.publicKey.contentToString())){
+                continue
+            }
+
+
 
             // Skip all blocks which are not voting blocks
             // and don't have a 'message' field in their transaction.
@@ -131,11 +137,11 @@ class VotingCommunity : Community() {
             when (voteJSON.get("VOTE_REPLY")) {
                 "YES" -> {
                     yesCount++
-                    voters.add(it.publicKey.contentToString())
+                    votes.add(it.publicKey.contentToString())
                 }
                 "NO" -> {
                     noCount++
-                    voters.add(it.publicKey.contentToString())
+                    votes.add(it.publicKey.contentToString())
                 }
                 else -> handleInvalidVote("Vote was not 'YES' or 'NO' but: '${voteJSON.get("VOTE_REPLY")}'.")
             }

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -79,6 +79,7 @@ class VotingCommunity : Community() {
      */
     fun countVotes(voters: List<String>, voteName: String, proposerKey: ByteArray): Pair<Int, Int> {
 
+        // ArrayList for keeping track of already counted votes
         val votes: MutableList<String> = ArrayList()
 
         var yesCount = 0

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -6,6 +6,7 @@ import nl.tudelft.ipv8.Community
 import nl.tudelft.ipv8.IPv8
 import nl.tudelft.ipv8.Overlay
 import nl.tudelft.ipv8.android.IPv8Android
+import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_PK
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity
@@ -91,15 +92,17 @@ class VotingCommunity : Community() {
                 continue
             }
 
-            if (!voters.contains(it.publicKey.toString())){
-                continue
-            }
-
-
-
             // Skip all blocks which are not voting blocks
             // and don't have a 'message' field in their transaction.
             if (it.type != "voting_block" || !it.transaction.containsKey("message")) {
+                continue
+            }
+
+            if (!voters.contains(it.publicKey.toString())){
+                Log.e("vote_debug", voters.toString())
+//                Log.e("vote_debug", trustchain.getPeerByPublicKeyBin(it.publicKey)?.publicKey.toString())
+//                Log.e("vote_debug", it.publicKey.joinToString("") { "%02x".format(it) })
+                Log.e("vote_debug", AndroidCryptoProvider.keyFromPublicBin(it.linkPublicKey).toString())
                 continue
             }
 

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -6,7 +6,6 @@ import nl.tudelft.ipv8.Community
 import nl.tudelft.ipv8.IPv8
 import nl.tudelft.ipv8.Overlay
 import nl.tudelft.ipv8.android.IPv8Android
-import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_PK
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity
@@ -49,7 +48,6 @@ class VotingCommunity : Community() {
 
         val voteList = JSONArray(voters)
 
-
         // Create a JSON object containing the vote subject
         val voteJSON = JSONObject()
             .put("VOTE_SUBJECT", voteSubject)
@@ -81,15 +79,16 @@ class VotingCommunity : Community() {
      */
     fun countVotes(voters: List<String>, voteName: String, proposerKey: ByteArray): Pair<Int, Int> {
 
-        var votes: MutableList<String> = ArrayList()
+        val votes: MutableList<String> = ArrayList()
 
         var yesCount = 0
         var noCount = 0
 
         // Crawl the chain of the proposer.
         for (it in trustchain.getChainByUser(proposerKey)) {
-            val block_public_key = defaultCryptoProvider.keyFromPublicBin(it.publicKey).toString()
+            val blockPublicKey = defaultCryptoProvider.keyFromPublicBin(it.publicKey).toString()
 
+            // Check whether vote has already been counted
             if (votes.contains(it.publicKey.contentToString())){
                 continue
             }
@@ -99,7 +98,6 @@ class VotingCommunity : Community() {
             if (it.type != "voting_block" || !it.transaction.containsKey("message")) {
                 continue
             }
-
 
             // Parse the 'message' field as JSON.
             val voteJSON = try {
@@ -131,11 +129,8 @@ class VotingCommunity : Community() {
                 continue
             }
 
-            if (!voters.contains(block_public_key)){
-                Log.e("vote_debug", voters.toString())
-//                Log.e("vote_debug", trustchain.getPeerByPublicKeyBin(it.publicKey)?.publicKey.toString())
-//                Log.e("vote_debug", it.publicKey.joinToString("") { "%02x".format(it) })
-                Log.e("vote_debug", defaultCryptoProvider.keyFromPublicBin(it.publicKey).toString())
+            // Check whether the voter is in voting list
+            if (!voters.contains(blockPublicKey)){
                 continue
             }
 

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -10,6 +10,7 @@ import nl.tudelft.ipv8.android.keyvault.AndroidCryptoProvider
 import nl.tudelft.ipv8.attestation.trustchain.EMPTY_PK
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainBlock
 import nl.tudelft.ipv8.attestation.trustchain.TrustChainCommunity
+import nl.tudelft.ipv8.keyvault.defaultCryptoProvider
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -87,6 +88,7 @@ class VotingCommunity : Community() {
 
         // Crawl the chain of the proposer.
         for (it in trustchain.getChainByUser(proposerKey)) {
+            val block_public_key = defaultCryptoProvider.keyFromPublicBin(it.publicKey).toString()
 
             if (votes.contains(it.publicKey.contentToString())){
                 continue
@@ -98,13 +100,6 @@ class VotingCommunity : Community() {
                 continue
             }
 
-            if (!voters.contains(it.publicKey.toString())){
-                Log.e("vote_debug", voters.toString())
-//                Log.e("vote_debug", trustchain.getPeerByPublicKeyBin(it.publicKey)?.publicKey.toString())
-//                Log.e("vote_debug", it.publicKey.joinToString("") { "%02x".format(it) })
-                Log.e("vote_debug", AndroidCryptoProvider.keyFromPublicBin(it.linkPublicKey).toString())
-                continue
-            }
 
             // Parse the 'message' field as JSON.
             val voteJSON = try {
@@ -133,6 +128,14 @@ class VotingCommunity : Community() {
             // A block with the same subject but no reply is the original vote proposal.
             if (!voteJSON.has("VOTE_REPLY")) {
                 // Block is the initial vote proposal because it does not have a VOTE_REPLY field.
+                continue
+            }
+
+            if (!voters.contains(block_public_key)){
+                Log.e("vote_debug", voters.toString())
+//                Log.e("vote_debug", trustchain.getPeerByPublicKeyBin(it.publicKey)?.publicKey.toString())
+//                Log.e("vote_debug", it.publicKey.joinToString("") { "%02x".format(it) })
+                Log.e("vote_debug", defaultCryptoProvider.keyFromPublicBin(it.publicKey).toString())
                 continue
             }
 

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/VotingCommunity.kt
@@ -91,7 +91,7 @@ class VotingCommunity : Community() {
                 continue
             }
 
-            if (!voters.contains(it.publicKey.contentToString())){
+            if (!voters.contains(it.publicKey.toString())){
                 continue
             }
 

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/ui/blocks/BlocksFragment.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/ui/blocks/BlocksFragment.kt
@@ -61,7 +61,7 @@ open class BlocksFragment : BaseFragment() {
                     try {
                         val voteJSON = JSONObject(it.block.transaction["message"].toString())
                         val voteName = voteJSON.get("VOTE_SUBJECT").toString()
-                        val tally = getVotingCommunity().countVotes(voteName, it.block.publicKey)
+                        val tally = getVotingCommunity().countVotes(getVotingCommunity().getPeers().map { it.publicKey.toString() },voteName, it.block.publicKey)
 
                         val text = "Yes votes: ${tally.first}. No votes: ${tally.second}."
 

--- a/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/ui/debug/DebugFragment.kt
+++ b/voting-android/src/main/java/nl/tudelft/ipv8/android/voting/ui/debug/DebugFragment.kt
@@ -53,7 +53,7 @@ class DebugFragment : BaseFragment() {
 
         builder.setPositiveButton("Create") { _, _ ->
             val proposal = input.text.toString()
-            getVotingCommunity().startVote(proposal)
+            getVotingCommunity().startVote(getVotingCommunity().getPeers().map { it.publicKey.toString() }, proposal)
             Toast.makeText(this.context, "Start voting procedure", Toast.LENGTH_SHORT).show()
         }
 


### PR DESCRIPTION
Adds functionality for sending one `any_counterparty` voting block instead of sending every peer a block.
**Summary of changes:**
- `startVote` and `countVote` require list of voters
- Removed `VOTE_END` block as it was not used
- `countVote` checks whether the owner of the casted vote block is in the voter list
